### PR TITLE
Makefile: No implementations provided for the following modules: Big_int

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CONVERT_LIBS=-use-ocamlfind -pkg sexplib,str
+CONVERT_LIBS=-use-ocamlfind -pkg sexplib,str,num
 OPTS=-cflags -warn-error,+a
 
 default: convert.native


### PR DESCRIPTION
```ocamlbuild -cflags -warn-error,+a -use-ocamlfind -pkg sexplib,str convert.native 
+ ocamlfind ocamlopt -linkpkg -package sexplib,str utils/utils.cmx utils/term.cmx input/program.cmx input/parser.cmx outputs/IntTRSFormat.cmx outputs/SMTFormat.cmx outputs/T2Format.cmx convert.cmx -o convert.native
File "_none_", line 1:
Error: No implementations provided for the following modules:
         Big_int referenced from utils/term.cmx, input/parser.cmx
Command exited with code 2.
Compilation unsuccessful after building 25 targets (0 cached) in 00:00:03.
Makefile:9: recipe for target 'convert.native' failed
make: *** [convert.native] Error 10
```

added num to required packages in order to have "big_int"